### PR TITLE
Resolve issue #36 (README Ajax loaded)

### DIFF
--- a/components/default/footer.php
+++ b/components/default/footer.php
@@ -5,10 +5,10 @@
 	</a>
 <?php endforeach;  endif;?>
 	<span title="Recent Commits" class="logo" data-request="action=recent_commits"><?php include(BASE . '/images/logos/git.svg')?></span>
-	<span title="GitHub Issues" class="logo" data-request="action=github_issues"><?php include(BASE . '/images/icons/warning.svg')?></span>
+	<span title="GitHub Issues" class="logo" data-request="action=github_issues"><?php include(BASE . '/images/icons/issues-open.svg')?></span>
 	<span title="Email Me" class="logo" data-show-modal="#email_admin_dialog"><?php include(BASE . '/images/icons/envelope.svg')?></span>
 	<span title="Contact Info" class="logo" data-show-modal="#contactDialog"><?php include(BASE . '/images/icons/people.svg')?></span>
-	<span title="Show README" class="logo" data-show-modal="#README"><?php include(BASE . '/images/icons/info.svg')?></span>
+	<span title="Show README" class="logo" data-request="action=README"><?php include(BASE . '/images/icons/info.svg')?></span>
 	<span title="Copyleft" class="logo" data-show-modal="#copyleftDialog"><?php include(BASE . '/images/logos/copyleft.svg')?></span>
 	<?php load('contact', 'copyleft', 'forms/email_admin')?>
 </footer>

--- a/components/default/handlers/action.php
+++ b/components/default/handlers/action.php
@@ -151,6 +151,18 @@
 				'#github_issues_dialog'
 			);
 		} break;
+
+		case 'README': {
+			$resp->append(
+				'body',
+				'<dialog id="README_dialog">
+				<button data-delete="#README_dialog">
+				</button><br />' . load_results('README') . '</dialog>'
+			)->showModal(
+				'#README_dialog'
+			);
+		} break;
+
 		case 'test': {
 			require_login('admin');
 

--- a/index.php
+++ b/index.php
@@ -56,9 +56,5 @@
 <body contextmenu="main_menu" <?=defined('GA') ?'data-ga="' . GA . '"' : null ?>>
 	<?php if(!$DB->connected) load('forms/install')?>
 	<?php load('forms/login', 'header', 'main', 'footer');?>
-	<dialog id="README">
-		<button data-close="#README"></button><br />
-		<?php load('README')?>
-	</dialog>
 </body>
 </html>


### PR DESCRIPTION
- Do not add dialog or load README in index
- Button in footer now is a `data-request` for README
- Created handler/case to load README in action
- Also, use new issues-open icon for Issues dialog
