### PR TITLE
Add referrer meta tag (origin). Fixes #60

### DIFF
--- a/components/default/head.php
+++ b/components/default/head.php
@@ -29,9 +29,10 @@
 	}
 ?>
 <head>
-<meta charset="<?=$head->charset?>"/>
 <title><?=(!(isset($pages) and is_string($pages->title) and strlen($pages->title)) or $pages->title === TITLE) ? TITLE : "{$pages->title} | " . TITLE ?></title>
 <base href="<?=URL?>/"/>
+<meta charset="<?=$head->charset?>"/>
+<meta name="referrer" content="origin"/>
 <!--=====================Standard meta tags==================================-->
 <meta name="description" content="<?=isset($pages->description) ? $pages->description : $head->description?>"/>
 <meta name="keywords" content="<?=isset($pages->keywords) ? $pages->keywords : $head->keywords?>"/>


### PR DESCRIPTION
Adds a meta tag with name of referrer and value of origin.
Prevents referrer header sent from containing too much data
or the specic URL